### PR TITLE
jrpcEngine - SafeEventEmitterProvider generic event type

### DIFF
--- a/src/jrpc/jrpcEngine.ts
+++ b/src/jrpc/jrpcEngine.ts
@@ -415,7 +415,7 @@ export type ProviderEvents = {
   data: (error: unknown, message: unknown) => void;
 };
 
-export interface SafeEventEmitterProvider extends SafeEventEmitter<ProviderEvents> {
+export interface SafeEventEmitterProvider<E extends ProviderEvents = ProviderEvents> extends SafeEventEmitter<E> {
   sendAsync: <T, U>(req: JRPCRequest<T>) => Promise<U>;
   send: <T, U>(req: JRPCRequest<T>, callback: SendCallBack<JRPCResponse<U>>) => void;
   request: <T, U>(args: RequestArguments<T>) => Promise<Maybe<U>>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current `SafeEventEmitterProvider` is using specific `ProviderEvents` event type and implementer can't extends event type of their own


## Description
<!--- Describe your changes in detail -->
Make `SafeEventEmitterProvider` use generic for event type default to `ProviderEvents`


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
local test, build success

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
