### PR TITLE
fix: handle URLSearchParams.size missing in slightly older browsers

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -56,14 +56,15 @@ export function getHashQueryParams(replaceUrl = false): HashQueryParamResult {
   if (replaceUrl) {
     const cleanUrl = new URL(window.location.origin + window.location.pathname);
     // https://dapp.com/#b64Params=asacsdnvdfv&state=sldjvndfkjvn&dappValue=sdjvndf
-    if (queryUrlParams.size > 0) {
+    // NB: `params.size !== 0` evaluates to true even if `.size` isn't implemented and returns `undefined`, like in Safari <17 and Chrome <113.
+    if (queryUrlParams.size !== 0) {
       queryUrlParams.delete("error");
       queryUrlParams.delete("state");
       queryUrlParams.delete("b64Params");
       queryUrlParams.delete("sessionNamespace");
       cleanUrl.search = queryUrlParams.toString();
     }
-    if (hashUrlParams.size > 0) {
+    if (hashUrlParams.size !== 0) {
       hashUrlParams.delete("error");
       hashUrlParams.delete("state");
       hashUrlParams.delete("b64Params");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/Web3Auth/Auth/issues/317

Some slightly older browsers, such as Safari <17 and Chrome <113, do not support `URLSearchParams.size`. `urlParams.size > 0`, the check for whether a `URLSearchParams` object contains any data, returns `false` in these browsers, causing the code to treat these params objects as empty and resulting in search and hash elements of the URL being erased when initializing a Web3Auth instance.

## Description
<!--- Describe your changes in detail -->

This PR changes the comparison from `u.size > 0` to `u.size !== 0`, which evaluates to `false` only if attribute `size` exists and the object doesn't contain any data.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The change was tested in Safari for iOS 16.4 and 17, macOS Safari 16 and 17, and Android Chrome 128 by signing into a web3auth client application that uses search and hash params to pass dapp data.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
